### PR TITLE
Panel update

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1 minimum-scale=1">
     <script src="src/constants.js"></script>
     <script src="src/parser.js"></script>
+    <script src="src/presets.js"></script>
     <script src="src/main.js" defer></script>
     <title>5DChess variant editor</title>
     <!-- No favicon -->
@@ -17,16 +18,42 @@
 [Size "8x8"]
 [Promotions "Q,R"]
 [r*nbqk*bnr*/p*p*p*p*p*p*p*p*/8/8/8/8/P*P*P*P*P*P*P*P*/R*NBQK*BNR*:0:1:w]</textarea>
-      <ul id="pieces">
-        <li class="two"><span class="noselect">Width:</span></li>
-        <li><input type="text" id="width" value="8"></li>
-        <li class="two"><span class="noselect">Height:</span></li>
-        <li><input type="text" id="height" value="8"></li>
-        <li class="two toggle" id="moved"><span>Moved</span></li>
-        <li class="two toggle" id="empty">Empty</li>
-        <li class="two toggle" id="standard">Standard</li>
-        <li class="three toggle" id="standard-t0">Standard T0</li>
-      </ul>
+      <div id="settings">
+        <section id="dimensions">
+          <div class="input-container">
+            <span>Width</span>
+            <input type="text" id="width" value="8">
+            <span>Height</span>
+            <input type="text" id="height" value="8">
+          </div>
+          <button id="empty">Set dimensions</button>
+        </section>
+        <section id="input-settings" class="mobile-first">
+          <span>Current mode:</span>
+          <div class="input-container">
+            <button id="edit-pieces" name="Edit pieces" class="selected">Add pieces</button>
+            <button id="space-around" name="Add boards">Add boards</button>
+          </div>
+          <span>Add next piece as:</span>
+          <div class="input-container">
+            <button id="not-moved" class="selected">Not yet moved</button>
+            <button id="moved">Already moved</button>
+          </div>
+        </section>
+        <section>
+          <span>Select preset:</span>
+          <select name="presets" id="presets">
+            <option value="Standard">Standard</option>
+            <option value="Standard - Turn Zero">Standard - Turn Zero</option>
+          </select>
+          <button id="set-preset">Load preset</button>
+        </section>
+        <!-- Screenshot button -->
+      </div>
+      <div id="pieces">
+        <ul id="pieces-black"></ul>
+        <ul id="pieces-white"></ul>
+      </div>
     </div>
     <div class="render">
       <canvas id="canvas">
@@ -35,7 +62,6 @@
       <canvas id="axes"></canvas>
       <div class="bar">
         <div id="status" class="ok">Loading...</div>
-        <div id="space-around"><button name="Add boards">Add boards</button></div>
       </div>
     </div>
   </body>

--- a/index.html
+++ b/index.html
@@ -57,8 +57,13 @@
       </canvas>
       <canvas id="axes"></canvas>
       <div id="pieces">
-        <ul id="pieces-white"></ul>
-        <ul id="pieces-black"><li id="black-phantom"></li></ul>
+        <div id="pieces-none-container">
+          <ul id="pieces-none"><li id="0" class="selected" title="No piece" onclick="selected_piece = 0; update_pieces();"><img src="cross.svg" /></li></ul>
+        </div>
+        <div class="mobile-vertical">
+          <ul id="pieces-white"></ul>
+          <ul id="pieces-black"></ul>
+        </div>
       </div>
       <div class="bar">
         <div id="status" class="ok">Loading...</div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 [Promotions "Q,R"]
 [r*nbqk*bnr*/p*p*p*p*p*p*p*p*/8/8/8/8/P*P*P*P*P*P*P*P*/R*NBQK*BNR*:0:1:w]</textarea>
       <div id="settings">
-        <section id="dimensions">
+        <section id="dimensions"> <!-- Dimension input -->
           <div class="input-container">
             <span>Width</span>
             <input type="text" id="width" value="8">
@@ -28,7 +28,7 @@
           </div>
           <button id="empty">Set dimensions</button>
         </section>
-        <section id="input-settings" class="mobile-first">
+        <section id="input-settings" class="mobile-first"> <!-- Mode settings -->
           <span>Current mode:</span>
           <div class="input-container">
             <button id="edit-pieces" name="Edit pieces" class="selected">Add pieces</button>
@@ -40,7 +40,7 @@
             <button id="moved">Already moved</button>
           </div>
         </section>
-        <section>
+        <section> <!-- Presets -->
           <span>Select preset:</span>
           <select name="presets" id="presets">
             <option value="Standard">Standard</option>
@@ -48,14 +48,16 @@
           </select>
           <button id="set-preset">Load preset</button>
         </section>
-        <!-- Screenshot button -->
+        <!-- TODO: Screenshot button -->
       </div>
     </div>
     <div class="render">
+      <!-- Canvases: -->
       <canvas id="canvas">
         Sorry, your browser needs to support canvases to render this!
       </canvas>
       <canvas id="axes"></canvas>
+      <!-- Piece selection palette: -->
       <div id="pieces">
         <div id="pieces-none-container">
           <ul id="pieces-none"><li id="0" class="selected" title="No piece" onclick="selected_piece = 0; update_pieces();"><img src="cross.svg" /></li></ul>
@@ -65,6 +67,7 @@
           <ul id="pieces-black"></ul>
         </div>
       </div>
+      <!-- Status bar: -->
       <div class="bar">
         <div id="status" class="ok">Loading...</div>
       </div>

--- a/index.html
+++ b/index.html
@@ -50,16 +50,16 @@
         </section>
         <!-- Screenshot button -->
       </div>
-      <div id="pieces">
-        <ul id="pieces-black"></ul>
-        <ul id="pieces-white"></ul>
-      </div>
     </div>
     <div class="render">
       <canvas id="canvas">
         Sorry, your browser needs to support canvases to render this!
       </canvas>
       <canvas id="axes"></canvas>
+      <div id="pieces">
+        <ul id="pieces-white"></ul>
+        <ul id="pieces-black"><li id="black-phantom"></li></ul>
+      </div>
       <div class="bar">
         <div id="status" class="ok">Loading...</div>
       </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,8 @@
 // Piece IDs
 const PIECES = {
     BLANK: 0,
+    W_BLANK: 0,
+    B_BLANK: 32,
     W_PAWN: 1,
     W_KNIGHT: 2,
     W_BISHOP: 3,
@@ -34,7 +36,7 @@ const PIECES = {
 
 // Piece assets
 const PIECE_ASSETS = {
-    [PIECES.BLANK]: "cross.svg",
+    [PIECES.W_BLANK]: "cross.svg",
     [PIECES.W_PAWN]: "assets/pawn-white.svg",
     [PIECES.W_KNIGHT]: "assets/knight-white.svg",
     [PIECES.W_BISHOP]: "assets/bishop-white.svg",
@@ -48,6 +50,7 @@ const PIECE_ASSETS = {
     [PIECES.W_CKING]: "assets/commonking-white.svg",
     [PIECES.W_RQUEEN]: "assets/royalqueen-white.svg",
 
+    [PIECES.B_BLANK]: "cross.svg",
     [PIECES.B_PAWN]: "assets/pawn-black.svg",
     [PIECES.B_KNIGHT]: "assets/knight-black.svg",
     [PIECES.B_BISHOP]: "assets/bishop-black.svg",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,6 @@
 // Piece IDs
 const PIECES = {
     BLANK: 0,
-    W_BLANK: 0,
-    B_BLANK: 32,
     W_PAWN: 1,
     W_KNIGHT: 2,
     W_BISHOP: 3,
@@ -36,7 +34,7 @@ const PIECES = {
 
 // Piece assets
 const PIECE_ASSETS = {
-    [PIECES.W_BLANK]: "cross.svg",
+    [PIECES.BLANK]: "cross.svg",
     [PIECES.W_PAWN]: "assets/pawn-white.svg",
     [PIECES.W_KNIGHT]: "assets/knight-white.svg",
     [PIECES.W_BISHOP]: "assets/bishop-white.svg",
@@ -50,7 +48,6 @@ const PIECE_ASSETS = {
     [PIECES.W_CKING]: "assets/commonking-white.svg",
     [PIECES.W_RQUEEN]: "assets/royalqueen-white.svg",
 
-    [PIECES.B_BLANK]: "cross.svg",
     [PIECES.B_PAWN]: "assets/pawn-black.svg",
     [PIECES.B_KNIGHT]: "assets/knight-black.svg",
     [PIECES.B_BISHOP]: "assets/bishop-black.svg",

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,7 +34,6 @@ const PIECES = {
 
 // Piece assets
 const PIECE_ASSETS = {
-    [PIECES.BLANK]: "cross.svg",
     [PIECES.W_PAWN]: "assets/pawn-white.svg",
     [PIECES.W_KNIGHT]: "assets/knight-white.svg",
     [PIECES.W_BISHOP]: "assets/bishop-white.svg",

--- a/src/main.js
+++ b/src/main.js
@@ -3,26 +3,31 @@ const ctx = canvas.getContext("2d");
 const axes = document.getElementById("axes");
 const axes_ctx = axes.getContext("2d");
 
+// Button list for selecting both white's and black's pieces
 const pieces_white = document.getElementById("pieces-white");
 const pieces_black = document.getElementById("pieces-black");
 
+// FEN input box
 const fen_input = document.getElementById("fen");
 
-const moved_button = document.getElementById("moved");
-const not_moved_button = document.getElementById("not-moved");
-
-const width_input = document.getElementById("width");
-const height_input = document.getElementById("height");
-
-const empty_button = document.getElementById("empty");
-const preset_dropdown = document.getElementById("presets");
-const preset_button = document.getElementById("set-preset");
-const std_button = document.getElementById("standard");
-const t0_button = document.getElementById("standard-t0");
-
+// "Current mode" buttons
 const space_around_button = document.getElementById("space-around");
 const edit_pieces_button = document.getElementById("edit-pieces");
 
+// "Add next piece as: [Not yet moved] / [Already moved]"
+const moved_button = document.getElementById("moved");
+const not_moved_button = document.getElementById("not-moved");
+
+// Input fields for the dimensions of the board and button to set the dimensions
+const width_input = document.getElementById("width");
+const height_input = document.getElementById("height");
+const empty_button = document.getElementById("empty");
+
+// Dropdown and button for the presets
+const preset_dropdown = document.getElementById("presets");
+const preset_button = document.getElementById("set-preset");
+
+// Status box
 const status = document.getElementById("status");
 
 const DPR = window.devicePixelRatio || 1;
@@ -62,6 +67,7 @@ let mouse_t = null;
 let prev_mouse_l = mouse_l;
 let prev_mouse_t = mouse_t;
 
+/// Updates the "selected" class for the piece selection buttons
 function update_pieces() {
     for (let button of piece_buttons) {
         if (!button) continue;
@@ -73,6 +79,7 @@ function update_pieces() {
     }
 }
 
+/// Updates the FEN field based on the `board_state` object.
 function update_fen() {
     let base_fen = fen_input.value;
 
@@ -124,6 +131,7 @@ function update_fen() {
     }
 }
 
+/// Resizes the canvas
 function resize_canvas() {
     canvas.width = canvas.clientWidth * DPR;
     canvas.height = canvas.clientHeight * DPR;
@@ -131,6 +139,7 @@ function resize_canvas() {
     axes.height = canvas.height;
 }
 
+/// Renders `board_state` on the main canvas and calls `render_axes`
 function render() {
     if (!assets_ready) return;
     if (!board_state || board_state instanceof Error) return;
@@ -272,10 +281,11 @@ function render() {
         ctx.strokeStyle = "#202a20";
         ctx.lineWidth = BORDER_WIDTH;
         ctx.stroke();
-        update_axes();
+        render_axes();
     }
 }
 
+/// Updates the status bar
 function update_status() {
     if (board_state instanceof Error) {
         status.innerText = board_state.toString();
@@ -294,6 +304,7 @@ function update_status() {
 }
 
 let was_error = false;
+/// Parses the input field if it has changed
 function update_input() {
     let value = fen_input.value;
     if (value === previous_value) return;
@@ -310,7 +321,8 @@ function update_input() {
     render();
 }
 
-function update_axes() {
+/// Renders the axes and super-physical coordinate labels
+function render_axes() {
     if (!assets_ready) return;
     if (!board_state || board_state instanceof Error) return;
     if (!position_data) return;
@@ -440,30 +452,20 @@ fen_input.onchange = fen_input.onkeyup = () => {
     update_input();
 };
 
+// Button behavior
+
 moved_button.onclick = () => {
     moved = true;
-    if (moved) {
-        moved_button.className = "selected";
-        not_moved_button.className = "";
-        window.document.body.classList.add("moved");
-    } else {
-        moved_button.className = "";
-        not_moved_button.className = "selected";
-        window.document.body.classList.remove("moved");
-    }
+    moved_button.className = "selected";
+    not_moved_button.className = "";
+    window.document.body.classList.add("moved");
 };
 
 not_moved_button.onclick = () => {
     moved = false;
-    if (moved) {
-        moved_button.className = "selected";
-        not_moved_button.className = "";
-        window.document.body.classList.add("moved");
-    } else {
-        moved_button.className = "";
-        not_moved_button.className = "selected";
-        window.document.body.classList.remove("moved");
-    }
+    moved_button.className = "";
+    not_moved_button.className = "selected";
+    window.document.body.classList.remove("moved");
 };
 
 empty_button.onclick = () => {
@@ -474,6 +476,7 @@ empty_button.onclick = () => {
 `;
     update_input();
 };
+
 preset_button.onclick = () => {
     fen_input.value = PRESETS[preset_dropdown.value];
     update_input();
@@ -481,29 +484,19 @@ preset_button.onclick = () => {
 
 space_around_button.onclick = () => {
     space_around = true;
-    if (space_around) {
-        space_around_button.className = "selected";
-        edit_pieces_button.className = "";
-    } else {
-        space_around_button.className = "";
-        edit_pieces_button.className = "selected";
-    }
+    space_around_button.className = "selected";
+    edit_pieces_button.className = "";
     render();
-    update_axes();
+    render_axes();
     return true;
 };
 
 edit_pieces_button.onclick = () => {
     space_around = false;
-    if (space_around) {
-        space_around_button.className = "selected";
-        edit_pieces_button.className = "";
-    } else {
-        space_around_button.className = "";
-        edit_pieces_button.className = "selected";
-    }
+    space_around_button.className = "";
+    edit_pieces_button.className = "selected";
     render();
-    update_axes();
+    render_axes();
     return true;
 };
 
@@ -523,12 +516,14 @@ window.onresize = () => {
     render();
 };
 
+// Canvas interaction
+
 canvas.onmousemove = (evt) => {
     mouse_vx = evt.layerX * DPR;
     mouse_vy = evt.layerY * DPR;
     prev_mouse_l = mouse_l;
     prev_mouse_t = mouse_t;
-    update_axes();
+    render_axes();
     if (mouse_down) {
         drag_piece();
     }
@@ -538,7 +533,7 @@ canvas.onmousedown = (evt) => {
     mouse_down = true;
     mouse_vx = evt.layerX * DPR;
     mouse_vy = evt.layerY * DPR;
-    update_axes();
+    render_axes();
     drag_piece();
 }
 
@@ -546,7 +541,7 @@ canvas.onmouseup = (evt) => {
     mouse_down = false;
     mouse_vx = evt.layerX * DPR;
     mouse_vy = evt.layerY * DPR;
-    update_axes();
+    render_axes();
 
     // TODO: do this on the second tap on mobile!
     if (

--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ const COORDS_REGEX = /^-?\d+:-?\d+/;
 
 let space_around = false;
 let selected_piece = PIECES.BLANK;
-let piece_buttons = [];
+let piece_buttons = [document.getElementById("0")];
 let piece_images = [];
 let assets_ready = false;
 let board_state = {};
@@ -65,7 +65,7 @@ let prev_mouse_t = mouse_t;
 function update_pieces() {
     for (let button of piece_buttons) {
         if (!button) continue;
-        if (selected_piece == button.id || selected_piece == 0 && button.id == PIECES.B_OFFSET) {
+        if (selected_piece == button.id) {
             button.className = "selected";
         } else {
             button.className = "";

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,0 +1,13 @@
+function make_preset(name, size, value) {
+    return `[Board "${name}"]\n[Mode "5D"]\n[Size "${size}"]\n${value.join("\n")}\n`;
+}
+
+const PRESETS = {
+    "Standard": make_preset("Standard", "8x8", [
+        "[r*nbqk*bnr*/p*p*p*p*p*p*p*p*/8/8/8/8/P*P*P*P*P*P*P*P*/R*NBQK*BNR*:0:1:w]",
+    ]),
+    "Standard - Turn Zero": make_preset("Standard", "8x8", [
+        "[r*nbqk*bnr*/p*p*p*p*p*p*p*p*/8/8/8/8/P*P*P*P*P*P*P*P*/R*NBQK*BNR*:0:0:b]",
+        "[r*nbqk*bnr*/p*p*p*p*p*p*p*p*/8/8/8/8/P*P*P*P*P*P*P*P*/R*NBQK*BNR*:0:1:w]",
+    ]),
+};

--- a/style.css
+++ b/style.css
@@ -8,7 +8,6 @@ body {
     overflow-x: hidden;
     overflow-y: hidden;
     --controls-width: 24em;
-    --piece-per-row: 8;
     --color-highlight: #78b0ff;
 }
 
@@ -135,11 +134,20 @@ section > .input-container {
     flex-direction: row;
 }
 
-#pieces-white, #pieces-black {
-    height: calc(var(--pieces-height) / var(--rows));
+.mobile-vertical {
     display: flex;
     flex-direction: row;
-    flex-wrap: nowrap;
+}
+
+#pieces-none-container {
+    background: #909090;
+}
+
+#pieces-white, #pieces-black, #pieces-none {
+    height: calc(var(--pieces-height));
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
     list-style: none;
     align-items: flex-start;
     padding: 0;
@@ -186,59 +194,12 @@ section > .input-container {
     border: 1px solid white;
 }
 
-#pieces li > span {
-    font-family: monospace;
-    font-size: 12pt;
-}
-
-#pieces li > span.noselect {
-    cursor: default;
-    user-select: none;
-}
-
-#pieces li.toggle {
-    cursor: pointer;
-    user-select: none;
-    border: 1px solid transparent;
-    box-sizing: border-box;
-    transition: 0.2s border-color, 0.2s background-color;
-}
-
-#pieces li.toggle:hover {
-    border: 1px solid #ffffff;
-}
-
-#pieces li.toggle:active, #pieces li.toggle.selected {
-    background: #606060;
-}
-
-#pieces li > input[type=text] {
-    font-family: monospace;
-    text-align: center;
-    background: #606060;
-    color: white;
-    width: inherit;
-    height: inherit;
-    margin: 0;
-    padding: 4px;
-    outline: none;
-    border: 1px solid #000000;
-    box-sizing: border-box;
-    font-size: calc(0.5 * var(--controls-width) / var(--piece-per-row));
-    transition: 0.2s border-color, 0.2s background-color;
-}
-
-#pieces li > input[type=text]:hover, #pieces li > input[type=text]:active {
-    border: 1px solid #ffffff;
-    background: #202a20;
-}
-
 .render {
     flex-grow: 1;
     height: 100vh;
     --status-height: 28px;
-    --n-pieces: 25;
-    --pieces-height: calc((100vw - var(--controls-width)) / var(--n-pieces) * var(--rows));
+    --n-pieces: 24;
+    --pieces-height: calc((100vw - var(--controls-width)) / (var(--n-pieces) + 1) * var(--rows));
     --rows: 1;
     position: relative;
     display: flex;
@@ -288,29 +249,30 @@ section > .input-container {
     color: #ffa0a0;
 }
 
-/* #space-around {
-    cursor: pointer;
-    border: 1px solid transparent;
-    box-sizing: border-box;
-    transition: 0.2s border-color, 0.2s background-color;
-    width: 7em;
-    text-align: center;
-    height: inherit;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-#space-around > button {
-    all: unset;
-}
+@media (max-width: 1300px) {
+    .render {
+        --n-pieces: 12;
+        --rows: 2;
+    }
 
-#space-around:hover {
-    border: 1px solid white;
-}
+    .mobile-vertical {
+        flex-direction: column;
+    }
 
-#space-around.selected {
-    background: #101010;
-} */
+    #pieces-white, #pieces-black, #pieces-none {
+        height: calc(var(--pieces-height) / 2);
+    }
+    #pieces-white, #pieces-black {
+        width: calc(var(--pieces-height) / var(--rows) * var(--n-pieces));
+    }
+
+    #black-phantom {
+        visibility: visible;
+        position: relative;
+        display: block;
+        flex-shrink: 0;
+    }
+}
 
 @media (max-width: 720px) {
     html {
@@ -321,12 +283,13 @@ section > .input-container {
         flex-direction: column-reverse;
         overflow-y: auto;
         --controls-width: calc(100vw - var(--scrollbar-width, 0px));
-        --rows: 5;
     }
 
     .render {
-        --pieces-height: calc(100vw / var(--n-pieces) * var(--rows));
+        --pieces-height: calc(100vw / (var(--n-pieces) + 1) * var(--rows));
         height: calc(100vh);
+        --n-pieces: 6;
+        --rows: 4;
     }
 
     #canvas, #axes {
@@ -367,25 +330,6 @@ section > .input-container {
 
 @media (max-width: 720px) and (min-aspect-ratio: 0.8) {
     body {
-        --piece-per-row: 12;
         --rows: 4;
-    }
-}
-
-@media (max-width: 1300px) {
-    .render {
-        --n-pieces: 13;
-        --rows: 2;
-    }
-
-    #pieces {
-        flex-direction: column;
-    }
-
-    #black-phantom {
-        visibility: visible;
-        position: relative;
-        display: block;
-        flex-shrink: 0;
     }
 }

--- a/style.css
+++ b/style.css
@@ -11,6 +11,8 @@ body {
     --color-highlight: #78b0ff;
 }
 
+/* Left panel */
+
 .controls {
     display: flex;
     flex-direction: column;
@@ -129,6 +131,39 @@ section > .input-container {
     border: 1px solid white;
 }
 
+/* Right panel */
+
+.render {
+    flex-grow: 1;
+    height: 100vh;
+    --status-height: 28px;
+    --n-pieces: 24;
+    --pieces-height: calc((100vw - var(--controls-width)) / (var(--n-pieces) + 1) * var(--rows));
+    --rows: 1;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+#axes {
+    width: 100%;
+    height: calc(100vh - var(--status-height) - var(--pieces-height));
+    flex-grow: 1;
+    margin: 0;
+    box-sizing: border-box;
+    object-fit: contain;
+}
+
+#canvas {
+    width: 100%;
+    height: calc(100vh - var(--status-height) - var(--pieces-height));
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+/* Bottom-right panel */
+
 #pieces {
     display: flex;
     flex-direction: row;
@@ -147,7 +182,7 @@ section > .input-container {
     height: calc(var(--pieces-height));
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     list-style: none;
     align-items: flex-start;
     padding: 0;
@@ -194,35 +229,6 @@ section > .input-container {
     border: 1px solid white;
 }
 
-.render {
-    flex-grow: 1;
-    height: 100vh;
-    --status-height: 28px;
-    --n-pieces: 24;
-    --pieces-height: calc((100vw - var(--controls-width)) / (var(--n-pieces) + 1) * var(--rows));
-    --rows: 1;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-}
-
-#axes {
-    width: 100%;
-    height: calc(100vh - var(--status-height) - var(--pieces-height));
-    flex-grow: 1;
-    margin: 0;
-    box-sizing: border-box;
-    object-fit: contain;
-}
-
-#canvas {
-    width: 100%;
-    height: calc(100vh - var(--status-height) - var(--pieces-height));
-    position: absolute;
-    top: 0;
-    left: 0;
-}
-
 .bar {
     flex-grow: 0;
     background: #202a20;
@@ -248,6 +254,8 @@ section > .input-container {
 #status.err {
     color: #ffa0a0;
 }
+
+/* Mobile & tablet */
 
 @media (max-width: 1300px) {
     .render {
@@ -290,6 +298,10 @@ section > .input-container {
         height: calc(100vh);
         --n-pieces: 6;
         --rows: 4;
+    }
+
+    #pieces-white, #pieces-black {
+        flex-wrap: wrap;
     }
 
     #canvas, #axes {

--- a/style.css
+++ b/style.css
@@ -15,12 +15,13 @@ body {
 .controls {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    min-height: 100vh;
     width: var(--controls-width);
     flex-shrink: 0;
     background: #202a20;
     color: white;
     box-shadow: -12px 0px 12px 12px rgba(0, 0, 0, 0.4);
+    overflow: hidden;
 }
 
 #fen {
@@ -35,6 +36,8 @@ body {
     line-break: anywhere;
     flex-shrink: 1;
     flex-grow: 1;
+    min-height: 12em;
+    box-shadow: 0px -8px 12px 12px rgba(0, 0, 0, 0.25);
 }
 
 #fen:focus {
@@ -57,6 +60,8 @@ body {
     align-items: center;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
+    border-radius: 2px;
+    box-shadow: 0px 2px 8px -3px rgba(0, 0, 0, 0.2);
 }
 
 section > .input-container {
@@ -131,14 +136,19 @@ section > .input-container {
 }
 
 #pieces-white, #pieces-black {
-    width: calc(var(--controls-width) / 2);
+    height: calc(var(--pieces-height) / var(--rows));
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     list-style: none;
     align-items: flex-start;
     padding: 0;
     margin: 0;
+}
+
+#black-phantom {
+    visibility: hidden;
+    position: absolute;
 }
 
 #pieces li {
@@ -147,13 +157,13 @@ section > .input-container {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(var(--controls-width) / var(--piece-per-row));
-    height: calc(var(--controls-width) / var(--piece-per-row));
+    width: calc(var(--pieces-height) / var(--rows));
+    height: calc(var(--pieces-height) / var(--rows));
 }
 
 #pieces li > img {
-    width: calc(var(--controls-width) / var(--piece-per-row));
-    height: calc(var(--controls-width) / var(--piece-per-row));
+    width: calc(var(--pieces-height) / var(--rows));
+    height: calc(var(--pieces-height) / var(--rows));
     background: #909090;
     border: 1px solid transparent;
     box-sizing: border-box;
@@ -174,14 +184,6 @@ section > .input-container {
 #pieces li > img:active {
     cursor: pointer;
     border: 1px solid white;
-}
-
-#pieces li.two {
-    width: calc(2 * var(--controls-width) / var(--piece-per-row));
-}
-
-#pieces li.three {
-    width: calc(3 * var(--controls-width) / var(--piece-per-row));
 }
 
 #pieces li > span {
@@ -231,11 +233,13 @@ section > .input-container {
     background: #202a20;
 }
 
-
 .render {
     flex-grow: 1;
     height: 100vh;
     --status-height: 28px;
+    --n-pieces: 25;
+    --pieces-height: calc((100vw - var(--controls-width)) / var(--n-pieces) * var(--rows));
+    --rows: 1;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -243,7 +247,7 @@ section > .input-container {
 
 #axes {
     width: 100%;
-    height: calc(100vh - var(--status-height));
+    height: calc(100vh - var(--status-height) - var(--pieces-height));
     flex-grow: 1;
     margin: 0;
     box-sizing: border-box;
@@ -252,7 +256,7 @@ section > .input-container {
 
 #canvas {
     width: 100%;
-    height: calc(100vh - var(--status-height));
+    height: calc(100vh - var(--status-height) - var(--pieces-height));
     position: absolute;
     top: 0;
     left: 0;
@@ -321,20 +325,23 @@ section > .input-container {
     }
 
     .render {
-        height: calc(100vh - var(--rows) * var(--controls-width) / var(--piece-per-row));
+        --pieces-height: calc(100vw / var(--n-pieces) * var(--rows));
+        height: calc(100vh);
     }
 
     #canvas, #axes {
-        height: calc(100vh - var(--status-height) - var(--rows) * var(--controls-width) / var(--piece-per-row));
+        height: calc(100vh - var(--status-height) - var(--pieces-height));
     }
 
     .controls {
         width: 100vw;
         flex-direction: column-reverse;
+        box-shadow: none;
     }
 
     #fen {
         font-size: 12pt;
+        box-shadow: 0px 8px 12px 12px rgba(0, 0, 0, 0.25);
     }
 
     #settings section:not(.mobile-first) {
@@ -362,5 +369,23 @@ section > .input-container {
     body {
         --piece-per-row: 12;
         --rows: 4;
+    }
+}
+
+@media (max-width: 1300px) {
+    .render {
+        --n-pieces: 13;
+        --rows: 2;
+    }
+
+    #pieces {
+        flex-direction: column;
+    }
+
+    #black-phantom {
+        visibility: visible;
+        position: relative;
+        display: block;
+        flex-shrink: 0;
     }
 }

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@ body {
     overflow-y: hidden;
     --controls-width: 24em;
     --piece-per-row: 8;
+    --color-highlight: #78b0ff;
 }
 
 .controls {
@@ -40,16 +41,107 @@ body {
     outline: none;
 }
 
+#settings {
+    font-family: monospace;
+    font-size: 12pt;
+    padding: 0.5em 1.0em;
+    display: flex;
+    flex-direction: column;
+}
+
+#settings section {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.2em 0.3em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+section > .input-container {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+}
+
+#width, #height {
+    width: 2em;
+    font-family: inherit;
+    font-size: inherit;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid black;
+    color: #f0f0f0;
+    padding: 2px 8px;
+    text-align: center;
+    transition: border-color 0.2s, color 0.2s;
+    border-radius: 2px;
+}
+
+#width:active, #width:focus, #width:hover, #height:active, #height:focus, #height:hover {
+    outline: none;
+    border: 1px solid white;
+    color: white;
+}
+
+#settings button {
+    font-family: inherit;
+    font-size: inherit;
+    background: transparent;
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    border-radius: 2px;
+    color: var(--color-highlight);
+    padding: 6px 8px;
+    cursor: pointer;
+    margin: 0.15em 0.1em;
+}
+
+#settings button:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid white;
+}
+
+#settings button:active {
+    border: 1px solid black;
+}
+
+#settings button:active, #settings button.selected {
+    color: white;
+    background: rgba(0, 0, 0, 0.25);
+}
+
+#settings select {
+    font-family: inherit;
+    font-size: inherit;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    border-radius: 2px;
+    padding: 6px 8px;
+    color: var(--color-highlight);
+    margin: 0.15em 0.1em;
+    transition: border-color 0.2s, color 0.2s;
+}
+
+#settings select:hover {
+    border: 1px solid white;
+}
+
 #pieces {
+    display: flex;
+    flex-direction: row;
+}
+
+#pieces-white, #pieces-black {
+    width: calc(var(--controls-width) / 2);
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     list-style: none;
+    align-items: flex-start;
     padding: 0;
     margin: 0;
 }
 
-#pieces > li {
+#pieces li {
     background: #909090;
     color: black;
     display: flex;
@@ -59,7 +151,7 @@ body {
     height: calc(var(--controls-width) / var(--piece-per-row));
 }
 
-#pieces > li > img {
+#pieces li > img {
     width: calc(var(--controls-width) / var(--piece-per-row));
     height: calc(var(--controls-width) / var(--piece-per-row));
     background: #909090;
@@ -68,41 +160,41 @@ body {
     transition: background-color 0.2s, border-color 0.2s;
 }
 
-#pieces > li.selected > img {
+#pieces li.selected > img {
     background: #606060;
     border: 1px solid #202020;
 }
 
-#pieces > li > img:hover {
+#pieces li > img:hover {
     cursor: pointer;
     background: #606060;
     border: 1px solid #d0d0d0;
 }
 
-#pieces > li > img:active {
+#pieces li > img:active {
     cursor: pointer;
     border: 1px solid white;
 }
 
-#pieces > li.two {
+#pieces li.two {
     width: calc(2 * var(--controls-width) / var(--piece-per-row));
 }
 
-#pieces > li.three {
+#pieces li.three {
     width: calc(3 * var(--controls-width) / var(--piece-per-row));
 }
 
-#pieces > li > span {
+#pieces li > span {
     font-family: monospace;
     font-size: 12pt;
 }
 
-#pieces > li > span.noselect {
+#pieces li > span.noselect {
     cursor: default;
     user-select: none;
 }
 
-#pieces > li.toggle {
+#pieces li.toggle {
     cursor: pointer;
     user-select: none;
     border: 1px solid transparent;
@@ -110,15 +202,15 @@ body {
     transition: 0.2s border-color, 0.2s background-color;
 }
 
-#pieces > li.toggle:hover {
+#pieces li.toggle:hover {
     border: 1px solid #ffffff;
 }
 
-#pieces > li.toggle:active, #pieces > li.toggle.selected {
+#pieces li.toggle:active, #pieces li.toggle.selected {
     background: #606060;
 }
 
-#pieces > li > input[type=text] {
+#pieces li > input[type=text] {
     font-family: monospace;
     text-align: center;
     background: #606060;
@@ -134,7 +226,7 @@ body {
     transition: 0.2s border-color, 0.2s background-color;
 }
 
-#pieces > li > input[type=text]:hover, #pieces > li > input[type=text]:active {
+#pieces li > input[type=text]:hover, #pieces li > input[type=text]:active {
     border: 1px solid #ffffff;
     background: #202a20;
 }
@@ -192,7 +284,7 @@ body {
     color: #ffa0a0;
 }
 
-#space-around {
+/* #space-around {
     cursor: pointer;
     border: 1px solid transparent;
     box-sizing: border-box;
@@ -214,7 +306,7 @@ body {
 
 #space-around.selected {
     background: #101010;
-}
+} */
 
 @media (max-width: 720px) {
     html {
@@ -244,15 +336,23 @@ body {
     #fen {
         font-size: 12pt;
     }
+
+    #settings section:not(.mobile-first) {
+        order: 1;
+    }
+
+    #settings section.mobile-first {
+        order: 0;
+    }
 }
 
 @media (hover: none) {
-    #pieces > li > img:hover {
+    #pieces li > img:hover {
         background: #909090;
         border: 1px solid transparent;
     }
 
-    #pieces > li.selected > img {
+    #pieces li.selected > img {
         background: #606060;
         border: 1px solid white;
     }


### PR DESCRIPTION
This improves the readability and understandability of the left panel, fixing things as:

- hard-coded "Standard" and "Standard T0" as presets
- confusing "Empty" board behavior
- "Width" and "Height" not doing anything unless "Empty" was pressed, which is hinted nowhere in the UI
- the "Moved" button making no sense
- the "Add boards" button being hidden in the lower-right corner and having to be toggled with little visual response

Now, settings are separated from the piece selection palette and are grouped in sections by behavior:

- The board resize section, which features the width, height input fields and a "Set dimensions" button
- A toggle between "Add boards" and "Add pieces" and a toggle between "Not yet moved" and "Already moved"
- A dropdown with a list of presets and a "Load preset" button

Closes #6
Closes #3 